### PR TITLE
GitHub Linguist support for adblock filters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+wjx-ublock.txt linguist-language=JSON linguist-detectable
+wjx-[Ae]*.txt linguist-language=AdBlock linguist-detectable

--- a/wjx-AdGuard.txt
+++ b/wjx-AdGuard.txt
@@ -1,3 +1,4 @@
+[AdGuard]
 ! Title: AdGuard拦截补充规则
 ! Update Time: 2022-4-30 23:15:00
 ! Update Details

--- a/wjx-AdGuardHome-strict.txt
+++ b/wjx-AdGuardHome-strict.txt
@@ -1,3 +1,4 @@
+[AdGuard]
 ! Title: AdGuardHome拦截补充规则（白名单版本）
 ! Update Time: 2021-5-21 13:28:00
 ! Ver.: 4.1.5

--- a/wjx-AdGuardHome.txt
+++ b/wjx-AdGuardHome.txt
@@ -1,3 +1,4 @@
+[AdGuard]
 ! Title: AdGuardHome拦截补充规则
 ! Update Time: 2021-5-21 13:28:00
 ! Ver.: 4.1.5

--- a/wjx-explorer-add.txt
+++ b/wjx-explorer-add.txt
@@ -1,3 +1,4 @@
+[AdGuard]
 ! Title: 浏览器补充规则
 ! Update Time: 2022-02-15 21:50:00
 ! Ver.: 1.1.3


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401